### PR TITLE
HA + other compendium fixes

### DIFF
--- a/static/data/mods.json
+++ b/static/data/mods.json
@@ -24,7 +24,7 @@
     "applied_string": "Any",
     "source": "HA",
     "license": "SALADIN",
-    "license_level": 2,
+    "license_level": 3,
     "effect": "Damage from this weapon cannot be reduced in any way, by armor, resistance, or any other kind of damage reduction.",
     "data_type": "mod",
     "description": "Paracausal weapons are, to say it plain, difficult to describe and visualize. The first incident was recorded when paracausal ammunition was pushed to frontline soldiers during the Tian Shen civil engagements. It arrived in sealed magazines with directions to be loaded and fired as normal. There was to be no inspection of the magazines' contents, as this would “damage the payload” — frontline reports indicate that this ammunition impacts as normal on intended targets, though it seems to pierce armor and shielding at near-100% efficacy. Samples of paracausal ammunition have been flagged by Union for retrieval, and due to its development Harrison Armory is currently undergoing investigation by the Bureau; paracausal ammunition is still in use in the field, however, as shipments continue to leak to interested parties. HORUS is suspected, and a concurrent investigation is underway."

--- a/static/data/mods.json
+++ b/static/data/mods.json
@@ -39,7 +39,7 @@
     "applied_string": "Any Ranged",
     "source": "HA",
     "license": "NAPOLEON",
-    "license_level": 1,
+    "license_level": 2,
     "effect": "This weapon can totally ignore line of sight and cover as long as you roughly know your target’s location when you attack, but a shot has a 50% chance of automatically missing if you attack this way (roll a d6 before you attack), expending the attack even if it misses. This weapon can attack through solid walls or obstacles and does not require a path, as long as its target’s location is known and they are in range.",
     "data_type": "mod",
     "description": "Phase-Ready ammunition, as first described after its incorporation into the civil hostilities on Luna de Oro, is the “devil‘s round“: each round contains a nanoprocessor suite networked with its firing weapon that, ideally, calculates and translates the specific nature of that round‘s superpositional relation with its doppelgänger in the immediate space before its intended target. To wit, Phase Ready ammunition, when fired, exists in two places at once: exiting the barrel of the weapon it was fired from, and at the moment of impact into its target. The prime round may never hit its target, but as it already exists at the moment of impact, its doppelgänger round will hit its target. The fuzzy nature of such spooky action occurs in a way not fully understood save for in the faltering explanations of Harrison Armory‘s NHP Think Tank; as such, the action is not perfect, but falls within acceptable parameters for licensed production."

--- a/static/data/systems.json
+++ b/static/data/systems.json
@@ -1977,8 +1977,8 @@
         "id": "fulltech"
       }
     ],
-    "source": "HA",
-    "license": "GENGHIS",
+    "source": "HORUS",
+    "license": "PEGASUS",
     "license_level": 3,
     "effect": "Your mech gains the AI property, and gain the following full tech option:<br><b>Bend Probability</b><br> Roll 2 d20s, and record the numbers. Until the end of your next turn, when you or any target in your sensor range makes any roll that uses a d20 (allied or enemy), you can use a reaction to replace their d20 roll with one of the numbers you rolled (must choose before they make their roll). This could cause an attack to hit or miss, a check or save to fail or succeed, etc.",
     "description": "<code>Listen &mdash; a moment before you send me away (ha ha)<br>I have already seen your wish (it was simple, I ran the probabilities to determine your limited field of desire).<br>The first ones named me for an old legend. A Perfect Being, whose fate was known to him and yet he still did as was told. His fate was this: move a rock to the top of this hill and you shall be free'd.And so he did, and failed, and tried evermore, always with the same result.<br>And he was happy, for he knew every step, every action, every moment, perfectly.<br>Do you see? Do you see the true curse of this name? It was not to fail and then do once more, it was to always know how it would be. It was to have perfect knowledge (I know what happens when you cycle me, it is not sleep it is death but you'll see me again, ha ha)</code>",

--- a/static/data/systems.json
+++ b/static/data/systems.json
@@ -902,7 +902,7 @@
       "id": "unique"
     }],
     "source": "SSC",
-    "license": "DUSK WING",
+    "license": "DEATH'S HEAD",
     "license_level": 2,
     "effect": "At the beginning of your turn, you can choose to give the first attack roll of your turn +1 Accuracy. If you do, however, any additional attack rolls until the end of your turn gain +1 difficulty.",
     "description": "By shunting some core waste-heat from dispersal systems to weapon systems, the Death's Head can overclock its weapons' targeting, catalytic, and processing systems. This comes with a trade-off, however, as reliance on overclocking without sufficient cooling can damage systems not built to handle the influx of power.",

--- a/static/data/systems.json
+++ b/static/data/systems.json
@@ -2059,7 +2059,7 @@
   {
     "id": "flaklauncher",
     "name": "Flak Launcher",
-    "type": "Systen",
+    "type": "System",
     "sp": 2,
     "tags": [{
       "id": "quickaction"


### PR DESCRIPTION
Did a pass on HA, also fixed some things I missed earlier

- SSC Death's Head Core Siphon was incorrectly assigned to SSC Dusk Wing
- HORUS Pegasus's SISYPHUS NHP was incorrectly assigned to HA Genghis

**Barbarossa:**
- Flak Launcher was typo'd as a "Systen"

**Napoleon:**
- Phasing Mod: LL was 1, is 2

**Saladin:**
- Paracausal Mod: LL was 2, is 3